### PR TITLE
Reduce README regeneration to Mondays and Thursdays

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,7 +3,7 @@ name: Update README
 on:
   push:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 1 * * 1,4"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changes the `Update README` schedule from daily (`0 0 * * *`) to Mondays and Thursdays at 01:00 (`0 1 * * 1,4`).

### Why

A daily rebuild produced mostly no-op commits, since the sources the template reads from move slowly. Twice a week keeps things fresh without the history churn.

### Notes

- Interpreted "Monday/Thursday night at 1am" literally as 01:00 **on** Monday and Thursday. If the intent was the night *following* those days, this should be `0 1 * * 2,5` instead.
- GitHub Actions cron is UTC-only, so this fires at 03:00 local under CEST and 02:00 under CET. Hitting exactly 01:00 local year-round isn't possible without editing the cron at DST changeover.
- The `push` and `workflow_dispatch` triggers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)